### PR TITLE
Update _posts.scss　本番環境の背景画像表示の為の修正

### DIFF
--- a/app/assets/stylesheets/modules/_posts.scss
+++ b/app/assets/stylesheets/modules/_posts.scss
@@ -92,7 +92,7 @@
 }
 // フッターscss
 .banner {
-  background-image: url(pict/bg-appBanner-pict.jpg);
+  background-image: image-url('pict/bg-appBanner-pict.jpg');
   height: 360px;
   padding: 100px 40px;
   background-size: cover;


### PR DESCRIPTION
本番環境で背景画像が読み込めてない為
_posts.scssファイルの背景画像の読み込みの記述を変更

background-image: url(pict/bg-appBanner-pict.jpg);
から
background-image: image-url('pict/bg-appBanner-pict.jpg');

urlを指定するのではなく、Railsが指定しているimage-urlメソッドを使うことで、デプロイ時にapp/assetsからpublic/assetsにファイルが移動する際に、自動的にファイルにdigestを付与してくれるようになります。（参考記事引用）