### PR TITLE
user登録時のカラム名nameからnicknameに変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,6 @@ class ApplicationController < ActionController::Base
   
   protected
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   
-  validates :name, presence: true, length: { maximum: 8 }, uniqueness: true
+  validates :nickname, presence: true, length: { maximum: 8 }, uniqueness: true
 
   # パスワードのバリデーション(半角英数字のみ入力を許可)
   VALID_PASSWORD_REGEX = /\A[a-z0-9]+\z/i

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -15,7 +15,7 @@
             %span.require__list ニックネーム
             %span.require__form 必須
           .input_form
-            = f.text_field :name, autofocus: true, class: "form_text", placeholder: "例)FURIMA一郎"
+            = f.text_field :nickname, autofocus: true, class: "form_text", placeholder: "例)FURIMA一郎"
         .sign-form__box
           .require
             %span.require__list メールアドレス

--- a/db/migrate/20200816041339_devise_create_users.rb
+++ b/db/migrate/20200816041339_devise_create_users.rb
@@ -4,7 +4,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
       ## Database authenticatable
-      t.string :name,               null: false
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
       ## Recoverable
@@ -36,7 +35,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.timestamps null: false
     end
 
-    add_index :users, :name, unique: true
     add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true
     # add_index :users, :confirmation_token,   unique: true

--- a/db/migrate/20200908113113_add_nickname_to_users.rb
+++ b/db/migrate/20200908113113_add_nickname_to_users.rb
@@ -1,0 +1,5 @@
+class AddNicknameToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :nickname, :string,      null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_26_132149) do
+ActiveRecord::Schema.define(version: 2020_09_08_113113) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id", null: false
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 2020_08_26_132149) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -54,8 +53,8 @@ ActiveRecord::Schema.define(version: 2020_08_26_132149) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "nickname", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
 
   factory :user do
-    name                  {"フリマ"}
+    nickname                  {"フリマ"}
     email                 {"ccc@gmail.com"}
     password              {"00000000"}
     password_confirmation {"00000000"}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,26 +2,26 @@ require 'rails_helper'
 describe User do
   describe '#create' do
 
-    it "nameとemail、passwordとpassword_confirmationが存在すれば登録できること" do
+    it "nicknameとemail、passwordとpassword_confirmationが存在すれば登録できること" do
       user = build(:user)
       expect(user).to be_valid
     end
 
     # ニックネームに関するテストコード
-    it "nameがない場合は登録できないこと" do
-      user = build(:user, name: nil)
+    it "nicknameがない場合は登録できないこと" do
+      user = build(:user, nickname: nil)
       user.valid?
-      expect(user.errors[:name]).to include("を入力してください")
+      expect(user.errors[:nickname]).to include("を入力してください")
     end
 
-    it "nameが9文字以上であれば登録できない" do
-      user = build(:user, name: "aaaaaaaaa")
+    it "nicknameが9文字以上であれば登録できない" do
+      user = build(:user, nickname: "aaaaaaaaa")
       user.valid?
-      expect(user.errors[:name]).to include("は8文字以内で入力してください")
+      expect(user.errors[:nickname]).to include("は8文字以内で入力してください")
     end
 
-    it "nameが8文字以下では登録できる" do
-      user = build(:user, name: "aaaaaaaa")
+    it "nicknameが8文字以下では登録できる" do
+      user = build(:user, nickname: "aaaaaaaa")
       expect(user).to be_valid
     end
 


### PR DESCRIPTION
[what]
devise_usersのマイグレーションファイルにrollbackした後にnameからnicknameに変更したが、単体テストが上手くいかなかった為、
記述を消し、別のマイグレーションファイルを作成してカラムを追加する方法で解決。
単体テストもクリア。