### PR TITLE
ログアウトページにログイン中にしかいけないよう実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!, only: [:index,:show]
+
   def index
   end
 

--- a/app/views/card/new.html.haml
+++ b/app/views/card/new.html.haml
@@ -50,7 +50,7 @@
         =link_to "電話番号の確認",'/#'
         %i.icon-arrow
       %li
-        =link_to "ログアウト",'/users/show'
+        =link_to "ログアウト",'/users'
         %i.icon-arrow
   = form_tag(pay_card_index_path, method: :post, id: 'charge-form',  name: "inputForm") do
     .card

--- a/app/views/card/show.html.haml
+++ b/app/views/card/show.html.haml
@@ -50,7 +50,7 @@
         =link_to "電話番号の確認",'/#'
         %i.icon-arrow
       %li
-        =link_to "ログアウト",'/users/show'
+        =link_to "ログアウト",'/users'
         %i.icon-arrow
   .card__confirmation
     %label 登録クレジットカード情報

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -50,7 +50,7 @@
         =link_to "電話番号の確認",'/#'
         %i.icon-arrow
       %li
-        =link_to "ログアウト",'/users/show'
+        =link_to "ログアウト",'/users'
         %i.icon-arrow
   .chapter
     .chapter__inner

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -50,7 +50,7 @@
         =link_to "電話番号の確認",'/#'
         %i.icon-arrow
       %li
-        = link_to 'ログアウト','/users/show'
+        = link_to 'ログアウト','/users'
         %i.icon-arrow
   .mypage__side__right
     = link_to '/#' do


### PR DESCRIPTION
what
before_actionを記述しログイン中にしかログアウトページ、マイページに飛べないよう実装
why
url を直接入力することで、未ログイン時にもログアウトページに飛べていた為修正。