### PR TITLE
商品出品ボタン、商品画像、トップページの出品された商品説明に関する修正

### DIFF
--- a/app/assets/stylesheets/modules/_new.scss
+++ b/app/assets/stylesheets/modules/_new.scss
@@ -110,25 +110,58 @@
   display: flex;
 }
 
-.send-btn {
-  width: 360px;
-  margin: 0 auto;
-  &__form {
-    color: white;
-    background-color: red;
-    border: 1px solid #ccc;
-    width: 100%;
-    font-size: 17px;
-    min-height: 48px;
-    padding: 0 24px;
+// 出品するボタン,user新規登録,ログインボタン
+.btn-list{
+  text-align: center;
+  font-size: 20px;
+
+  .send-btn {
+    width: 360px;
+    margin: 0 auto;
+
+    &__form {
+      color: white;
+      background-color: red;
+      border: 1px solid #ccc;
+      width: 100%;
+      font-size: 17px;
+      min-height: 48px;
+      padding: 0 24px;
+      cursor: pointer;
+    }
+    &__back {
+      background-color: #ccc;
+      text-align: center;
+      line-height: 50px;
+      display: block;
+      width: 100%;
+      height: 50px;
+      color: blue;
+      margin-top: 30px;
+    }
   }
-  &__back {
-    text-align: center;
-    display: block;
-    width: 100%;
-    height: 20px;
-    color: blue;
-    margin-top: 30px;
+  .registration__btn{
+    display: flex;
+    justify-content: space-around;
+    padding-top: 20px;
+
+    &__list{
+      background-color: #3ccace;
+      color: #ffffff;
+      border: 1px #3ccace solid;
+      width: 40%;
+      height: 50px;
+      line-height: 50px;
+      border-radius: 100px;
+      text-align: center;
+      font-size: 20px;
+
+      a{
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+    }
   }
 }
 

--- a/app/assets/stylesheets/modules/_posts.scss
+++ b/app/assets/stylesheets/modules/_posts.scss
@@ -354,52 +354,32 @@ a {
       display: flex;
       overflow: scroll;
 
-      .relatedlist{
-        width: 700px;
-        height: 300px;
-        font-size: 20px;
-        margin: 0 auto;
-        color: #3ccace;
-        text-align: start;
-  
-  
-        .related_images {
+      .container__box__list {
+        width: 220px;
+
+        .list__image {
           width: 220px;
-          padding-top: 10px;
-          color: black;
-          font-size: 16px;
-          text-align: center;
-          padding-top: 20px;
-          display: flex;
+          height: 150px;
+          object-fit: cover;
+        }
+        .list__body {
+          background-color: white;
+          color: #333;
+          padding: 16px;
 
-          .container__box__list {
-            width: 220px;
-
-            .list__image {
-              width: 220px;
-              height: 150px;
-              object-fit: cover;
-            }
-            .list__body {
-              background-color: white;
-              color: #333;
-              padding: 16px;
-
-              &__name {
-                overflow: hidden;
-                line-height: 1.5;
-                font-size: 16px;
-              }
-              ul {
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
-              }
-              p {
-                font-size: 10px;
-                text-align: left;
-              }
-            }
+          &__name {
+            overflow: hidden;
+            line-height: 1.5;
+            font-size: 16px;
+          }
+          ul {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+          }
+          p {
+            font-size: 10px;
+            text-align: left;
           }
         }
       }

--- a/app/assets/stylesheets/modules/users.scss
+++ b/app/assets/stylesheets/modules/users.scss
@@ -213,3 +213,39 @@ a {
     font-size: 14px;
   }
 }
+
+// 登録完了後のページ
+.signup__contents{
+  background-color: #f8f8f8;
+
+  &__main{
+    width: 700px;
+    margin: 0 auto;
+    padding: 24px 40px 40px;
+    background-color: #ffffff;
+    text-align: center;
+
+    .message{
+      font-size: 20px;
+      height: 50px;
+    }
+
+    .root-btn{
+      background-color: #3ccace;
+      width: 40%;
+      height: 50px;
+      line-height: 50px;
+      color: #ffffff;
+      border: 1px #3ccace solid;
+      border-radius: 100px;
+      font-size: 20px;
+      margin: 10px auto;
+    }
+
+    a{
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+  }
+}

--- a/app/views/devise/registrations/create_address.html.haml
+++ b/app/views/devise/registrations/create_address.html.haml
@@ -1,8 +1,10 @@
 .sign-header
   = render "sign_header"
-.sign__main
-  .sign__main__contents
-    %h2 登録が完了しました
-    = link_to "トップへ戻る", root_path
+.signup__contents
+  .signup__contents__main
+    .message
+      %h3 登録が完了しました。
+    .root-btn
+      = link_to "トップに戻る",root_path
 .sign-footer
   = render "sign_footer"

--- a/app/views/posts/_main.html.haml
+++ b/app/views/posts/_main.html.haml
@@ -93,11 +93,9 @@
   .pickup__container__box
     .container__box__head
       = link_to "新規投稿商品",'/#'
-    .container__box__lists
-      .wrapper
-        = render "relatedlist"
-     
-              
+    .wrapper
+      = render "relatedlist"
+
 -# ピックアップブランド
 .pickup__container
   .pickup__container__head
@@ -105,6 +103,5 @@
   .pickup__container__box
     .container__box__head
       = link_to "アーカイバ",'/#'
-    .container__box__lists
-      .wrapper
-        = render "relatedlist"
+    .wrapper
+      = render "relatedlist"

--- a/app/views/posts/_relatedlist.html.haml
+++ b/app/views/posts/_relatedlist.html.haml
@@ -1,18 +1,17 @@
-.relatedlist
-  .related_images
-    - @product.each do |product|
-      = link_to product_path(id: product.id) do
-        .container__box__list
-          - ft_image = product.images.first
-          = image_tag ft_image.image.url, class: "list__image"
-          .list__main
-            .list__main__name
-              = product.name
-            .list_details
-              %ul
-                %li 
-                  = "¥"
-                  = product.price
-                %li 
-                  %i.fas.fa-star 0
-              %p (税込み)
+.container__box__lists
+  - @product.each do |product|
+    = link_to product_path(id: product.id) do
+      .container__box__list
+        - ft_image = product.images.first
+        = image_tag ft_image.image.url, class: "list__image"
+        .list__body
+          .list__body__name
+            = product.name
+          .list__body__details
+            %ul
+              %li 
+                = "¥"
+                = product.price
+              %li 
+                %i.fas.fa-star 0
+            %p (税込み)

--- a/app/views/products/new.haml
+++ b/app/views/products/new.haml
@@ -91,9 +91,19 @@
           .price-form
             %span ¥
             = f.number_field :price, placeholder: "0", class: "price-number"
-      .send-btn
-        = f.submit '出品する', class: "send-btn__form"
-        = link_to 'もどる', root_path, class: "send-btn__back"
+      .btn-list
+        - if user_signed_in?
+          .send-btn
+            = f.submit '出品する', class: "send-btn__form"
+            = link_to 'トップにもどる', root_path, class: "send-btn__back"
+        - else
+          %p
+            ※商品を出品するにはアカウント登録またはログインが必要です。
+          .registration__btn
+            .registration__btn__list
+              =link_to "ログイン",new_user_session_path, method: :get
+            .registration__btn__list
+              =link_to "新規会員登録",new_user_registration_path, method: :get
       .attention
         %p 禁止されている行為および出品物を必ずご確認ください。偽ブランド品や盗品物などの販売は犯罪であり、法律により処罰される可能性があります。 また、出品をもちまして加盟店規約に同意したことになります。
 .footer_new


### PR DESCRIPTION
[what]
・image_uploder.rbのリサイズに関する記述を変更（サイズを100から500に上げました）
・posts/_main.html.hamlの商品一覧（ピックアップカテゴリー）のビューに関する調整
・商品出品画面でユーザー未ログインの状態の時は出品ボタンを表示させずに新規登録とログインのボタンが表示される様に修正

[why]
・商品出品された画像の画質が悪かった為
・商品説明の各項目のビューが崩れて表示がおかしくなっていた為
・商品出品画面でユーザー未ログインの状態で出品ボタンをクリックするとフリーズしてしまう為