### PR TITLE
商品詳細ページでユーザーがログインしていない場合のボタンの表示

### DIFF
--- a/app/assets/stylesheets/modules/products.scss
+++ b/app/assets/stylesheets/modules/products.scss
@@ -177,33 +177,36 @@ a {
         // 購入・編集・削除ボタンcss
         .btn-list {
           width: 100%;
-          height: 50px;
-          display: flex;
-          justify-content: space-around;
-          text-align: center;
+          height: 100px;
 
-          .edit_btn {
-            background-color: #3ccace;
-            width: 40%;
-            height: 50px;
-            line-height: 50px;
-            color: #ffffff;
-            border: 1px #3ccace solid;
-            border-radius: 100px;
-            font-size: 20px;
-            margin-top: 10px;
-          }
+          .btns{
+            display: flex;
+            justify-content: space-around;
+            text-align: center;
 
-          .destroy_btn {
-            background-color: red;
-            width: 40%;
-            height: 50px;
-            line-height: 50px;
-            color: #ffffff;
-            border: 1px #3ccace solid;
-            border-radius: 100px;
-            font-size: 20px;
-            margin-top: 10px;
+            .edit_btn {
+              background-color: #3ccace;
+              width: 40%;
+              height: 50px;
+              line-height: 50px;
+              color: #ffffff;
+              border: 1px #3ccace solid;
+              border-radius: 100px;
+              font-size: 20px;
+              margin-top: 10px;
+            }
+
+            .destroy_btn {
+              background-color: red;
+              width: 40%;
+              height: 50px;
+              line-height: 50px;
+              color: #ffffff;
+              border: 1px #3ccace solid;
+              border-radius: 100px;
+              font-size: 20px;
+              margin-top: 10px;
+            }
           }
 
           .confirm-link {
@@ -216,6 +219,25 @@ a {
             font-size: 20px;
             margin-top: 10px;
             border-radius: 100px;
+            margin: 0 auto;
+            }
+
+          .registration__btn{
+            display: flex;
+            justify-content: space-around;
+            padding-top: 20px;
+        
+            &__list{
+              background-color: #3ccace;
+              color: #ffffff;
+              border: 1px #3ccace solid;
+              width: 300px;
+              height: 50px;
+              line-height: 50px;
+              border-radius: 100px;
+              text-align: center;
+              font-size: 20px;
+            }
           }
 
           a {

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -109,7 +109,7 @@
               .registration__btn__list
                 =link_to "新規会員登録",new_user_registration_path, method: :get
         .comment_index
-          この商品に対するコメント
+          コメント表示欄<br>親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。
         .commentBox
           = form_tag root_path do
             .commentContents

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -92,13 +92,22 @@
         -# ログインしているユーザーと出品したユーザーが一致しているかどうか
         .btn-list
           - if user_signed_in? && current_user.id == @product.user_id
-            .edit_btn
-              =link_to "この商品の情報を編集する","/products/#{@product.id}/edit", method: :get
-            .destroy_btn
-              =link_to "この商品の情報を削除する","/products/#{@product.id}", method: :delete, data: {confirm: "本当に削除しますか？"}
-          - else
+            .btns
+              .edit_btn
+                =link_to "この商品の情報を編集する","/products/#{@product.id}/edit", method: :get
+              .destroy_btn
+                =link_to "この商品の情報を削除する","/products/#{@product.id}", method: :delete, data: {confirm: "本当に削除しますか？"}
+          - elsif user_signed_in?
             .confirm-link
               = link_to "この商品を購入する","/purchase/#{@product.id}", method: :get
+          - else
+            %p
+              ※商品を購入するにはアカウント登録またはログインが必要です。
+            .registration__btn
+              .registration__btn__list
+                =link_to "ログイン",new_user_session_path, method: :get
+              .registration__btn__list
+                =link_to "新規会員登録",new_user_registration_path, method: :get
         .comment_index
           この商品に対するコメント
         .commentBox


### PR DESCRIPTION
[what]
products/show.html.hamlにてユーザーがログインしていない場合は新規登録、ログインボタンが表示される様に修正

[why]ログインしているのを忘れてうっかり購入ボタンをクリックするとエラーを引き起こしてしまう為