### PR TITLE
商品出品ページ遷移のpathの指定変更

### DIFF
--- a/app/views/posts/_footer.html.haml
+++ b/app/views/posts/_footer.html.haml
@@ -39,7 +39,7 @@
   = link_to image_tag("logo/logo-white.png",class: "footer__img"),root_path
   .footer__end
     ©FURIMA
-= link_to new_product_path do
+= link_to new_product_path, method: :get do
   .purchase__btn
     .purchase__btn__text
       出品する

--- a/app/views/products/new.haml
+++ b/app/views/products/new.haml
@@ -1,6 +1,7 @@
 .new__header
   .new__icon
-    = link_to image_tag('logo/logo.png',class: 'icon-image')
+    = link_to new_product_path, method: :get do
+      = image_tag('logo/logo.png',class: 'icon-image')
 .main-new
   .product-content
     = form_with model: @product, class: "form" do |f|


### PR DESCRIPTION
[what]
posts/_footer.html.haml内の出品アイコンのpathの指定にmethod::getを追記
products/new.haml内のheaderのアイコンのlinkを上記と同様に指定

[why]
posts/_footer.html.haml内の出品アイコンから出品ページに遷移出来る様にしていたが、遷移後に画像を投稿すると複数枚の同じ画像が縦に並んで表示されてしまう為。
ページ遷移後に更新をすると現象は解消されるが、変更前の記述でページ遷移し直すと再び複数枚の同じ画像が表示されてしまう為