### PR TITLE
商品詳細ページに商品のカテゴリの親、子、孫全て載せる

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -21,6 +21,7 @@ class ProductsController < ApplicationController
   end
 
   def show
+    @parents = Category.all.order("id ASC").limit(13)
   end
 
 

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -6,11 +6,11 @@
   .main_nav__next
     >
   .main_nav__list
-    = link_to "カテゴリー",'/#'
+    = link_to(@product.category.parent.parent.name)
   .main_nav__next
     >
   .main_nav__list
-    = link_to "服のサイズなど",'/#'
+    = link_to(@product.category.parent.name)
   .main_nav__next
     >
   .main_nav__list
@@ -50,6 +50,10 @@
                 %th
                   カテゴリー
                 %td
+                  = link_to(@product.category.parent.parent.name)
+                  %br
+                  = link_to(@product.category.parent.name)
+                  %br
                   = link_to(@product.category.name)
               %tr
                 %th


### PR DESCRIPTION
[what]
商品詳細ページにて商品のカテゴリーの親から孫までを掲載するように調整をした。
products/show.html.hamlのカテゴリー の欄

[why]
ユーザーにどのカテゴリーから目的の商品を探せば良いのか分かりやすくする為